### PR TITLE
Replace binary data with placeholder text when logging

### DIFF
--- a/lib/redis/rails/instrumentation.rb
+++ b/lib/redis/rails/instrumentation.rb
@@ -17,6 +17,7 @@ class Redis
 
           output = cmds.map do |name, *args|
             if !args.empty?
+	      args = args.map { |arg| arg.respond_to?(:encoding) && arg.encoding == Encoding::ASCII_8BIT ? 'BINARY DATA' : arg }
               "[ #{name.to_s.upcase} #{args.join(' ')} ]"
             else
               "[ #{name.to_s.upcase} ]"


### PR DESCRIPTION
I wrote this hacky workaround for a problem I was having, any binary data we were storing in Redis was being written verbatim to the console during logging and it was super ugly and throwing all sorts of errors in my terminal. Not sure if this is being actively developed or anything, figured I might as well throw this here if it is and a proper solution can be worked out.