### PR TITLE
Add new ruby versions to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ jobs:
           - 2.5
           - 2.6
           - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
           - jruby
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Include new Ruby versions in build matrix to ensure things are still working.